### PR TITLE
Fixes for python bindings for ShaderGen

### DIFF
--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -47,7 +47,7 @@ const TypeDesc* TypeDesc::registerType(const string& name, unsigned char basetyp
         throw ExceptionShaderGenError("A type with name '" + name + "' is already registered");
     }
 
-    TypeDescPtr ptr = TypeDescPtr(new TypeDesc(name, basetype, semantic, size, editable, channelMapping));
+	TypeDescPtr ptr = TypeDescPtr(new TypeDesc(name, basetype, semantic, size, editable, channelMapping), TypeDesc::destroy);
     map[name] = ptr;
 
     return ptr.get();

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -60,6 +60,12 @@ class TypeDesc
     /// Throws an exception if no type with that name is found.
     static const TypeDesc* get(const string& name);
 
+	// Structured destructor for typeDesc making it possible to destroy TypeDescs
+	// but making shared_ptrs in general failing
+	static void destroy(TypeDesc* typeDesc) {
+		delete typeDesc;
+	}
+
     /// Return the name of the type.
     const string& getName() const { return _name; }
 
@@ -105,7 +111,10 @@ class TypeDesc
   private:
     TypeDesc(const string& name, unsigned char basetype, unsigned char semantic, size_t size,
              bool editable, const ChannelMap& channelMapping);
-
+	
+	// Make destructor private so casually making a shared_ptr to a typedesc doesn't
+	// delete it since it's returned as a pointer from the type map while held as a shared_ptr
+	~TypeDesc() {}
     const string _name;
     const unsigned char _basetype;
     const unsigned char _semantic;

--- a/source/PyMaterialX/PyMaterialXGenShader/PyColorManagement.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyColorManagement.cpp
@@ -55,7 +55,7 @@ void bindPyColorManagement(py::module& mod)
         .def("loadLibrary", &mx::ColorManagementSystem::loadLibrary)
         .def("supportsTransform", &mx::ColorManagementSystem::supportsTransform);
 
-    py::class_<mx::DefaultColorManagementSystem, mx::DefaultColorManagementSystemPtr>(mod, "DefaultColorManagementSystem")
-        .def_static("create", &mx::DefaultColorManagementSystem::create)
+    py::class_<mx::DefaultColorManagementSystem, mx::DefaultColorManagementSystemPtr, mx::ColorManagementSystem>(mod, "DefaultColorManagementSystem")
+		.def_static("create", &mx::DefaultColorManagementSystem::create)
         .def("getName", &mx::DefaultColorManagementSystem::getName);
 }

--- a/source/PyMaterialX/PyMaterialXGenShader/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyModule.cpp
@@ -16,6 +16,7 @@ void bindPyHwShaderGenerator(py::module& mod);
 void bindPyGenOptions(py::module& mod);
 void bindPyShaderStage(py::module& mod);
 void bindPyUtil(py::module& mod);
+void bindPyTypeDesc(py::module& mod);
 
 PYBIND11_MODULE(PyMaterialXGenShader, mod)
 {
@@ -30,4 +31,5 @@ PYBIND11_MODULE(PyMaterialXGenShader, mod)
     bindPyGenOptions(mod);
     bindPyShaderStage(mod);
     bindPyUtil(mod);
+	bindPyTypeDesc(mod);
 }

--- a/source/PyMaterialX/PyMaterialXGenShader/PyTypeDesc.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyTypeDesc.cpp
@@ -1,0 +1,31 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <PyMaterialX/PyMaterialX.h>
+
+#include <MaterialXGenShader/TypeDesc.h>
+
+namespace py = pybind11;
+namespace mx = MaterialX;
+
+void bindPyTypeDesc(py::module& mod)
+{
+	// Set nodelete as destructor on returned TypeDescs since they are owned
+	// by the container they are stored in and should not be destroyed when 
+	// garbage collected by the python interpreter
+	py::class_<mx::TypeDesc, std::unique_ptr<MaterialX::TypeDesc, py::nodelete>>(mod, "TypeDesc")
+		.def("getName", &mx::TypeDesc::getName)
+		.def("getBaseType", &mx::TypeDesc::getBaseType)
+		.def("getChannelIndex", &mx::TypeDesc::getChannelIndex)
+		.def("getSemantic", &mx::TypeDesc::getSemantic)
+		.def("getSize", &mx::TypeDesc::getSize)
+		.def("isEditable", &mx::TypeDesc::isEditable)
+		.def("isScalar", &mx::TypeDesc::isScalar)
+		.def("isAggregate", &mx::TypeDesc::isAggregate)
+		.def("isArray", &mx::TypeDesc::isArray)
+		.def("isFloat2", &mx::TypeDesc::isFloat2)
+		.def("isFloat3", &mx::TypeDesc::isFloat3)
+		.def("isFloat4", &mx::TypeDesc::isFloat4);
+}


### PR DESCRIPTION
Added missing baseclass for DefaultColorManagementSystem
Added bindings for TypeDesc
Make destruction explicit for TypeDesc since they are managed as singletons in a map and they should be destroyed when the map is destroyed.